### PR TITLE
Undo "fix css"

### DIFF
--- a/views/layout.jet
+++ b/views/layout.jet
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>Seedhelper</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootswatch/4.1.1/cyborg/bootstrap.min.css" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://bootswatch.com/4/cyborg/bootstrap.min.css" crossorigin="anonymous">
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/bootstrap.native@2.0.21/dist/bootstrap-native-v4.min.js"></script>
     <style>
         .form-control::-webkit-input-placeholder, .form-control::-moz-placeholder, .form-control:-ms-input-placeholder, .form-control:-moz-placeholder, .form-control::placeholder, .form-control:placeholder, .form-control::placeholder {


### PR DESCRIPTION
Using stackpath.bootstrapcdn.com is not necessary as the original bootswatch website was fixed.